### PR TITLE
missing version option description in the doc section

### DIFF
--- a/ansible_collections/netfoundry/platform/plugins/modules/netfoundry_network.py
+++ b/ansible_collections/netfoundry/platform/plugins/modules/netfoundry_network.py
@@ -50,6 +50,10 @@ options:
         type: str
         choices: ["small","medium","large"]
         default: small
+    version:
+        description: The product version number in SemVer notation e.g. 7.3.17.
+        required: false
+        type: str
     wait:
         description: seconds to wait for specified status (see async example)
         required: false


### PR DESCRIPTION
not sure if the version option was left out of the documentation section on purpose or not.